### PR TITLE
chore: Harden API client generation against bad spec fetch

### DIFF
--- a/.github/workflows/gen-client.yml
+++ b/.github/workflows/gen-client.yml
@@ -15,6 +15,15 @@ jobs:
           private-key: ${{ secrets.CQ_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+      - name: Generate GitHub App token for platform repo
+        id: app-token-platform
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.CQ_APP_ID }}
+          private-key: ${{ secrets.CQ_APP_PRIVATE_KEY }}
+          repositories: |
+            platform
+          permission-contents: read
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -22,7 +31,7 @@ jobs:
 
       - name: Get Specs File
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-platform.outputs.token }}
         run: |
           curl --fail-with-body --silent --show-error --location \
             -H "Authorization: token ${GH_TOKEN}" \

--- a/.github/workflows/gen-client.yml
+++ b/.github/workflows/gen-client.yml
@@ -21,8 +21,26 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Get Specs File
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          curl -H "Authorization: token ${{ steps.app-token.outputs.token }}" https://raw.githubusercontent.com/cloudquery/platform/main/platform/api/servergen/spec.json -o spec.json
+          curl --fail-with-body --silent --show-error --location \
+            -H "Authorization: token ${GH_TOKEN}" \
+            https://raw.githubusercontent.com/cloudquery/platform/main/platform/api/servergen/spec.json \
+            -o spec.json
+
+      - name: Validate spec
+        run: |
+          if ! jq empty spec.json 2>/dev/null; then
+            echo "::error::spec.json is not valid JSON — refusing to regenerate the client"
+            cat spec.json
+            exit 1
+          fi
+          paths_count=$(jq '.paths | length' spec.json)
+          if [ "${paths_count:-0}" -lt 1 ]; then
+            echo "::error::spec.json has no paths — refusing to regenerate an empty client"
+            exit 1
+          fi
 
       - name: Set up Go 1.x
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6


### PR DESCRIPTION
The `Generate API Client` workflow silently shipped an empty client in v2.0.1. Root cause chain:

1. The spec fetch used the current-repo app token, which has no access to the private `cloudquery/platform` repo, so `raw.githubusercontent.com` returned **HTTP 404**.
2. `curl` had no `--fail`, so the `404: Not Found` body was written into `spec.json`.
3. That body is valid YAML with zero paths, so oapi-codegen generated a compilable but **empty** client (exit 0), and it auto-merged and released.

Fixes, matching the working pattern in `cloudquery-api-go`:
- Mint a second, `platform`-scoped app token (`repositories: platform`, `contents: read`) and use it for the spec fetch.
- `curl --fail-with-body` so a non-200 fetch fails the job.
- New `Validate spec` step: reject a `spec.json` that isn't valid JSON or has no paths, before regenerating.

Note: still requires the CQ App to be installed on `cloudquery/platform` with `contents: read`.