### PR TITLE
chore: Correct spec.json path in gen-client workflow URL

### DIFF
--- a/.github/workflows/gen-client.yml
+++ b/.github/workflows/gen-client.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           curl --fail-with-body --silent --show-error --location \
             -H "Authorization: token ${GH_TOKEN}" \
-            https://raw.githubusercontent.com/cloudquery/platform/main/platform/api/servergen/spec.json \
+            https://raw.githubusercontent.com/cloudquery/platform/main/api/servergen/spec.json \
             -o spec.json
 
       - name: Validate spec


### PR DESCRIPTION
The workflow fetched `spec.json` from a path with an extra `platform/` prefix, returning 404; corrected the URL to `api/servergen/spec.json`.